### PR TITLE
Update [Girder] : Migrate to Girder 5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.swp
 node_modules/
+dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include girder_vip/web_client/dist *

--- a/README.md
+++ b/README.md
@@ -20,29 +20,30 @@ This plugins allows to :
 - npm >= 10
 - python >= 3.10
 - redis service installed and active ([installation guide](https://redis.io/docs/latest/operate/oss_and_stack/install/archive/install-redis/))
+- mongod service installed and active ([installation guide](https://www.mongodb.com/docs/manual/installation/))
 
 ## Installation
 
 The girder prod server is installed in a virtual env in the `$GIRDER_ENV` folder
 
-1. Activate the virtualenv : `. $GIRDER_ENV/bin/activate`
+1. Activate the virtualenv : \
+`. $GIRDER_ENV/bin/activate`
 1. Stop girder with a `kill $pid` (if already running)
-1.  Uninstall plugin (if already installed)
-   1. `pip uninstall girder_vip`
-   1. `rm -rf $GIRDER_ENV/lib/pythonX/site-packages/girder_vip`
-1. `pip install git+https://github.com/virtual-imaging-platform/VIP-girder-plugin.git@master`
+1.  Uninstall plugin (if already installed) \
+`pip uninstall girder_vip` \
+`rm -rf $GIRDER_ENV/lib/pythonX/site-packages/girder_vip`
+1. Run `npm install` and `npm run build` in the `girder_vip/web_client` folder
+2. `pip install git+https://github.com/virtual-imaging-platform/VIP-girder-plugin.git@master`
 2. Install Girder 5.x necessary dependencies : \
 `pip install girder-plugin-worker`
 3. Kill previous Girder workers (if already running) : \
 `pkill -f 'celery -A girder_worker.app worker'`
 4. Set necessary environment variables : \
 `export GIRDER_WORKER_BROKER=redis://127.0.0.1:6379/0` \
-`export GIRDER_WORKER_BACKEND=redis://127.0.0.1:6379/1`\
-`export CELERY_BROKER_URL=redis://127.0.0.1:6379/0`
+`export GIRDER_WORKER_BACKEND=redis://127.0.0.1:6379/1`
 3. Launch background girder worker : \
 `celery -A girder_worker.app worker -Q local --detach
 --logfile=/tmp/girder-celery.log --pidfile=/tmp/girder-celery.pid`
-2. Run `npm install` and `npm run build` in the `girder_vip/web_client` folder
 1. `nohup girder serve &`
 
 ## Administrator configuration

--- a/README.md
+++ b/README.md
@@ -14,20 +14,38 @@ This plugins allows to :
 - After the launch, follow in girder the advancement of the execution
 - Easy access to the results when it is over
 
+## Requirements
+
+- node >= 20
+- npm >= 10
+- python >= 3.10
+- redis service installed and active ([installation guide](https://redis.io/docs/latest/operate/oss_and_stack/install/archive/install-redis/))
+
 ## Installation
 
 The girder prod server is installed in a virtual env in the `$GIRDER_ENV` folder
 
 1. Activate the virtualenv : `. $GIRDER_ENV/bin/activate`
-1. Stop girder with a `kill $pid`
-1. (si le plugin est déja installé) Désinstaller le plugin
+1. Stop girder with a `kill $pid` (if already running)
+1.  Uninstall plugin (if already installed)
    1. `pip uninstall girder_vip`
-   1. `rm -rf $GIRDER_ENV/lib/python3.7/site-packages/girder_vip`
+   1. `rm -rf $GIRDER_ENV/lib/pythonX/site-packages/girder_vip`
 1. `pip install git+https://github.com/virtual-imaging-platform/VIP-girder-plugin.git@master`
-1. `girder build` (it could be long)
+2. Install Girder 5.x necessary dependencies : \
+`pip install girder-plugin-worker`
+3. Kill previous Girder workers (if already running) : \
+`pkill -f 'celery -A girder_worker.app worker'`
+4. Set necessary environment variables : \
+`export GIRDER_WORKER_BROKER=redis://127.0.0.1:6379/0` \
+`export GIRDER_WORKER_BACKEND=redis://127.0.0.1:6379/1`\
+`export CELERY_BROKER_URL=redis://127.0.0.1:6379/0`
+3. Launch background girder worker : \
+`celery -A girder_worker.app worker -Q local --detach
+--logfile=/tmp/girder-celery.log --pidfile=/tmp/girder-celery.pid`
+2. Run `npm install` and `npm run build` in the `girder_vip/web_client` folder
 1. `nohup girder serve &`
 
-## Administator configuration
+## Administrator configuration
 
 In the plugin configuration page, the girder administrator must :
 - verify the vip url or select another CARMIN platform url
@@ -43,12 +61,7 @@ Each user must configure its own VIP api key in its girder account in order to a
 ## Development
 
 The girder development server is installed in a virtual env in the `$GIRDER_ENV` folder.
-The first time, the plugin needs to be intalled as in the production installation.
-
-Then, to test client/javascript changes :
-1. Activate the virtualenv : `. $GIRDER_ENV/bin/activate`
-1. `girder build --watch-plugin vip` (let it run in a seperate shell)
-  This will automatically rebuild the plugin when a file changes in `$GIRDER_ENV/lib/python3.7/site-packages/girder_vip/web_client/*/`
-1. Change the source files to test
-   1. Either directly in `$GIRDER_ENV/lib/python3.7/site-packages/girder_vip/web_client/*/`
-   1. Either by fetching changes in a github repository : `pip install -I --no-deps git+https://github.com/my-github-user/VIP-girder-plugin.git@my-branch`. Les options `-I --no-deps` permettent d'écraser ce qui est déjà installé et de ne pas se soucier des dépendances.
+The first time, the plugin needs to be installed as in the production installation.
+To test client/javascript changes there is two options :
+ - Use watch mode to automatically build the client files : `npm run watch` with `girder serve`
+ - remove the plugin from Girder and install it again (see Installation)

--- a/girder_vip/__init__.py
+++ b/girder_vip/__init__.py
@@ -7,10 +7,10 @@
 # Copyright (C) 2018
 # -----------------------------------------------------------------------------
 
-import os
+from pathlib import Path
 
 # from Girder
-from girder.plugin import GirderPlugin
+from girder.plugin import GirderPlugin, registerPluginStaticContent
 from girder.models.user import User as UserModel
 from girder.constants import AccessType
 
@@ -22,9 +22,15 @@ from .vipHandler import VipHandler
 
 class VipPlugin(GirderPlugin):
     DISPLAY_NAME = 'VIP applications'
-    CLIENT_SOURCE_PATH = 'web_client'
 
     def load(self, info):
+        registerPluginStaticContent(
+            plugin = 'vip',
+            js=['/vip-plugin.umd.js'],
+            css=[],
+            staticDir=Path(__file__).parent / 'web_client' / 'dist',
+            tree=info['serverRoot'],
+        )
         vipHandler = VipHandler()
         # Model PipelineExecution
         info['apiRoot'].vip_execution = execution_rest.Execution()

--- a/girder_vip/execution_rest.py
+++ b/girder_vip/execution_rest.py
@@ -1,5 +1,5 @@
 from girder.api.rest import Resource, filtermodel
-from girder import logger
+from girder.utility import logger
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.constants import AccessType

--- a/girder_vip/vipHandler.py
+++ b/girder_vip/vipHandler.py
@@ -1,7 +1,5 @@
-from girder import logprint
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.models.user import User
 from girder.constants import AccessType
 from girder.models.user import User as UserModel
 from girder.models.setting import Setting
@@ -15,8 +13,6 @@ class VipHandler(object):
     def __init__(self):
         super(VipHandler, self).__init__()
         self._model = UserModel()
-        self.__users = User()
-
 
     @access.user
     @autoDescribeRoute(

--- a/girder_vip/web_client/collections/ExecutionCollection.js
+++ b/girder_vip/web_client/collections/ExecutionCollection.js
@@ -1,7 +1,7 @@
 // Import utilities
-import { SORT_DESC } from '@girder/core/constants';
+const { SORT_DESC } = girder.constants;
 
-import Collection from '@girder/core/collections/Collection';
+const Collection = girder.collections.Collection;
 
 import ExecutionModel from '../models/ExecutionModel';
 

--- a/girder_vip/web_client/collections/FavoritePipelineCollection.js
+++ b/girder_vip/web_client/collections/FavoritePipelineCollection.js
@@ -1,6 +1,6 @@
 // Import utilities
-import Collection from '@girder/core/collections/Collection';
-import { restRequest } from '@girder/core/rest';
+const Collection = girder.collections.Collection;
+const { restRequest } = girder.rest;
 
 // Import models
 import FavoritePipelineModel from '../models/FavoritePipelineModel';

--- a/girder_vip/web_client/models/ExecutionModel.js
+++ b/girder_vip/web_client/models/ExecutionModel.js
@@ -1,5 +1,5 @@
-import Model from '@girder/core/models/Model';
-import { restRequest } from '@girder/core/rest';
+const Model = girder.models.Model;
+const { restRequest } = girder.rest;
 
 var ExecutionModel = Model.extend({
     resourceName: "vip_execution",

--- a/girder_vip/web_client/models/FavoritePipelineModel.js
+++ b/girder_vip/web_client/models/FavoritePipelineModel.js
@@ -1,5 +1,5 @@
 // Import utilities
-import Model from '@girder/core/models/Model';
+const Model = girder.models.Model;
 
 const FavoritePipelineModel = Model.extend({
     resourceName: 'favorite_pipeline',

--- a/girder_vip/web_client/package.json
+++ b/girder_vip/web_client/package.json
@@ -1,14 +1,22 @@
 {
         "name": "@girder/vip",
-        "version": "3.0.2",
+        "version": "3.0.3",
         "description": "Use of VIP applications",
         "homepage": "gitlab",
-        "bugs" : {},
-        "peerDependencies" :{
-          "@girder/core": "*"
+        "bugs": {},
+        "private": true,
+        "scripts": {
+                "build": "webpack",
+                "watch": "webpack --watch --mode development"
         },
-        "girderPlugin": {
-                "name" : "vip",
-                "main" : "./main.js"
+        "devDependencies": {
+                "pug": "^3.0.4",
+                "pug-plugin": "^6.1.0",
+                "webpack": "^5.0.0",
+                "webpack-cli": "^5.0.0"
+        },
+        "engines": {
+                "node": ">=20",
+                "npm": ">=10"
         }
 }

--- a/girder_vip/web_client/routes.js
+++ b/girder_vip/web_client/routes.js
@@ -1,8 +1,8 @@
 // Import utilities
-import router from '@girder/core/router';
-import events from '@girder/core/events';
+const router = girder.router;
+const events = girder.events;
 
-import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
+const { exposePluginConfig } = girder.utilities.PluginUtils;
 
 exposePluginConfig('vip', 'plugins/vip/config');
 

--- a/girder_vip/web_client/templates/launchVipPipeline.pug
+++ b/girder_vip/web_client/templates/launchVipPipeline.pug
@@ -86,6 +86,6 @@ form.vip-launch-pipeline-form(role="form")
                   input.form-control.input-sm(id="vip-launch-" + param.pid,type="text", placeholder="Default : " + param.defaultValue)
                   small.help-block= param.description
 
-  button.btn.btn-success#run-execution(type="submit", data-loading-text="<i class='animate-spin icon-spin6'></i> Execute")
+  button.btn.btn-success#run-execution(type="submit")
     i.icon-play
     |  Execute

--- a/girder_vip/web_client/utilities/vipPluginUtils.js
+++ b/girder_vip/web_client/utilities/vipPluginUtils.js
@@ -1,12 +1,11 @@
 // Import utilities
-import _ from 'underscore';
-import { getCurrentUser } from '@girder/core/auth';
-import { restRequest, cancelRestRequests } from '@girder/core/rest';
-import events from '@girder/core/events';
-import FolderModel from '@girder/core/models/FolderModel';
-import ApiKeyCollection from '@girder/core/collections/ApiKeyCollection.js'
-import ApiKeyModel from '@girder/core/models/ApiKeyModel.js'
-import FolderCollection from '@girder/core/collections/FolderCollection';
+const { getCurrentUser } = girder.auth;
+const { restRequest, cancelRestRequests } = girder.rest;
+const events = girder.events;
+const FolderModel = girder.models.FolderModel;
+const ApiKeyCollection = girder.collections.ApiKeyCollection;
+const ApiKeyModel = girder.models.ApiKeyModel;
+const FolderCollection = girder.collections.FolderCollection;
 import { VIP_PLUGIN_API_KEY, NEEDED_TOKEN_SCOPES } from '../constants';
 import CarminClient from '../vendor/carmin/carmin-client';
 

--- a/girder_vip/web_client/views/ConfigView.js
+++ b/girder_vip/web_client/views/ConfigView.js
@@ -1,10 +1,9 @@
-import _ from 'underscore';
-import events from '@girder/core/events';
-import { restRequest } from '@girder/core/rest';
+const events = girder.events;
+const { restRequest } = girder.rest;
 import { messageGirder} from '../utilities/vipPluginUtils';
 
-import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
-import View from '@girder/core/views/View';
+const PluginConfigBreadcrumbWidget = girder.views.widgets.PluginConfigBreadcrumbWidget;
+const View = girder.views.View;
 
 import ConfigViewTemplate from '../templates/configView.pug';
 

--- a/girder_vip/web_client/views/FileListWidget.js
+++ b/girder_vip/web_client/views/FileListWidget.js
@@ -1,9 +1,9 @@
 // Import utilities
-import { wrap } from '@girder/core/utilities/PluginUtils';
+const { wrap } = girder.utilities.PluginUtils;
 import { hasTheVipApiKeyConfigured, isPluginActivatedOn } from '../utilities/vipPluginUtils';
 
 // Import views
-import FileListWidget from '@girder/core/views/widgets/FileListWidget';
+const FileListWidget = girder.views.widgets.FileListWidget;
 import ListPipelinesWidget from './ListPipelinesWidget';
 
 // Import about Creatis

--- a/girder_vip/web_client/views/FileSelector.js
+++ b/girder_vip/web_client/views/FileSelector.js
@@ -1,16 +1,15 @@
 // Import utilities
-import _ from 'underscore';
-import events from '@girder/core/events';
-import { wrap } from '@girder/core/utilities/PluginUtils';
-import CollectionCollection from '@girder/core/collections/CollectionCollection';
-import FileCollection from '@girder/core/collections/FileCollection';
+const events = girder.events;
+const { wrap } = girder.utilities.PluginUtils;
+const CollectionCollection = girder.collections.CollectionCollection;
+const FileCollection = girder.collections.FileCollection;
 import { getVipConfig } from '../utilities/vipPluginUtils';
-import { getCurrentUser } from '@girder/core/auth';
+const { getCurrentUser } = girder.auth;
 
 // Import views
-import View from '@girder/core/views/View';
-import FileListWidget from '@girder/core/views/widgets/FileListWidget';
-import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
+const View = girder.views.View;
+const FileListWidget = girder.views.widgets.FileListWidget;
+const BrowserWidget = girder.views.widgets.BrowserWidget;
 
 // import template
 import FileSelectorTemplate from '../templates/fileSelector.pug';
@@ -182,7 +181,7 @@ var FileSelector = BrowserWidget.extend({
 
 // remove the download and view (and rocket link) next to the items
 // (only on this file selection use)
-import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+const HierarchyWidget = girder.views.widgets.HierarchyWidget;
 import FolderSelector from "./FolderSelector";
 wrap(HierarchyWidget, 'initialize', function(initialize, settings) {
   settings = settings || {};

--- a/girder_vip/web_client/views/FolderSelector.js
+++ b/girder_vip/web_client/views/FolderSelector.js
@@ -1,9 +1,9 @@
 // Import utilities
-import CollectionCollection from '@girder/core/collections/CollectionCollection';
+const CollectionCollection = girder.collections.CollectionCollection;
 import { getVipConfig } from '../utilities/vipPluginUtils';
 
 // Import views
-import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
+const BrowserWidget = girder.views.widgets.BrowserWidget;
 
 var FolderSelector = BrowserWidget.extend({
     initialize: function (settings) {

--- a/girder_vip/web_client/views/HeaderUserView.js
+++ b/girder_vip/web_client/views/HeaderUserView.js
@@ -1,10 +1,10 @@
 // Import utilities
-import { wrap } from '@girder/core/utilities/PluginUtils';
+const { wrap } = girder.utilities.PluginUtils;
 import { hasTheVipApiKeyConfigured } from '../utilities/vipPluginUtils';
-import events from '@girder/core/events';
+const events = girder.events;
 
 // Import views
-import HeaderUserView from '@girder/core/views/layout/HeaderUserView';
+const HeaderUserView = girder.views.layout.HeaderUserView;
 import ListPipelinesWidget from './ListPipelinesWidget';
 
 // Import templates

--- a/girder_vip/web_client/views/ItemListWidget.js
+++ b/girder_vip/web_client/views/ItemListWidget.js
@@ -1,16 +1,16 @@
 // Import utilities
-import { wrap } from '@girder/core/utilities/PluginUtils';
+const { wrap } = girder.utilities.PluginUtils;
 
-import router from '@girder/core/router';
-import FileCollection from '@girder/core/collections/FileCollection';
+const router = girder.router;
+const FileCollection = girder.collections.FileCollection;
 import { hasTheVipApiKeyConfigured, isPluginActivatedOn, messageGirder } from '../utilities/vipPluginUtils';
-import { confirm } from '@girder/core/dialog';
+const { confirm } = girder.dialog;
 
 // Import views
-import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
+const ItemListWidget = girder.views.widgets.ItemListWidget;
 import ListPipelinesWidget from './ListPipelinesWidget';
-import FolderView from '@girder/core/views/body/FolderView';
-import CollectionView from '@girder/core/views/body/CollectionView';
+const FolderView = girder.views.body.FolderView;
+const CollectionView = girder.views.body.CollectionView;
 
 // Import Templates
 import ButtonLaunchPipeline from '../templates/buttonLaunchPipeline.pug';

--- a/girder_vip/web_client/views/LaunchVipPipeline.js
+++ b/girder_vip/web_client/views/LaunchVipPipeline.js
@@ -1,29 +1,25 @@
 // Import utilities
-import events from '@girder/core/events';
-import router from '@girder/core/router';
-import { getCurrentUser } from '@girder/core/auth';
-import { restRequest } from '@girder/core/rest';
+const events = girder.events;
+const router = girder.router;
+const { getCurrentUser } = girder.auth;
+const { restRequest } = girder.rest;
 import { messageGirder, doVipRequest, useVipConfig, hasTheVipApiKeyConfigured, verifyApiKeysConfiguration, getVipConfig } from '../utilities/vipPluginUtils';
-import CollectionCollection from '@girder/core/collections/CollectionCollection';
+const CollectionCollection = girder.collections.CollectionCollection;
 
 // Import models
-import FolderModel from '@girder/core/models/FolderModel';
+const FolderModel = girder.models.FolderModel;
 import ExecutionModel from '../models/ExecutionModel';
 
 // Import views
-import View from '@girder/core/views/View';
+const View = girder.views.View;
 import FileSelector from './FileSelector';
 import FolderSelector from './FolderSelector';
-import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
-import { confirm } from '@girder/core/dialog';
-import 'bootstrap/js/button';
+const BrowserWidget = girder.views.widgets.BrowserWidget;
+const { confirm } = girder.dialog;
 
 // Import templates
 import LaunchTemplate from '../templates/launchVipPipeline.pug';
 import SuccessDialog from '../templates/executionSuccessDialog.pug';
-
-// reuse system config style to separate input sections
-import '@girder/core/stylesheets/body/systemConfig.styl';
 
 var LaunchVipPipeline = View.extend({
 
@@ -367,12 +363,12 @@ var LaunchVipPipeline = View.extend({
         msg += error;
       }
       messageGirder("danger", msg);
-      $('#run-execution').button('reset');
+      $('#run-execution').prop('disabled', false).html("<i class='icon-play'></i> Execute");
     });
 
     // Loading animation on the button
     messageGirder("info", "Launching execution, this could take a few seconds", 10000);
-    $('#run-execution').button('loading');
+    $('#run-execution').prop('disabled', true).html("<i class='animate-spin icon-spin6'></i> Execute");
   },
 
   createResultFolder: function (executionName, parentFolder) {

--- a/girder_vip/web_client/views/ListPipelinesWidget.js
+++ b/girder_vip/web_client/views/ListPipelinesWidget.js
@@ -1,18 +1,16 @@
 // Import utilities
-import _ from 'underscore';
-import events from '@girder/core/events';
-import router from '@girder/core/router';
-import { cancelRestRequests } from '@girder/core/rest';
+const events = girder.events;
+const router = girder.router;
+const { cancelRestRequests } = girder.rest;
 import { hasTheVipApiKeyConfigured, sortPipelines, messageGirder, doVipRequest, verifyApiKeysConfiguration } from '../utilities/vipPluginUtils';
 
 // Import collections
 import FavoritePipelineCollection from "../collections/FavoritePipelineCollection";
 
 // Import views
-import View from '@girder/core/views/View';
+const View = girder.views.View;
 import LaunchVipPipeline from './LaunchVipPipeline';
-import LoadingAnimation from '@girder/core/views/widgets/LoadingAnimation';
-import '@girder/core/utilities/jquery/girderModal';
+const LoadingAnimation = girder.views.widgets.LoadingAnimation;
 
 // Import templates
 import ListPipelinesTemplate from '../templates/listPipelines.pug';

--- a/girder_vip/web_client/views/MyExecutions.js
+++ b/girder_vip/web_client/views/MyExecutions.js
@@ -1,14 +1,12 @@
 // Import utilities
-import _ from 'underscore';
-import moment from 'moment';
-import router from '@girder/core/router';
+const router = girder.router;
 import * as constants from '../constants';
-import events from '@girder/core/events';
+const events = girder.events;
 import { hasTheVipApiKeyConfigured, messageGirder, doVipRequest } from '../utilities/vipPluginUtils';
 
 // Import views
-import { confirm } from '@girder/core/dialog';
-import View from '@girder/core/views/View';
+const { confirm } = girder.dialog;
+const View = girder.views.View;
 
 // Import collections
 import ExecutionCollection from '../collections/ExecutionCollection';

--- a/girder_vip/web_client/views/UploadFolderWidget.js
+++ b/girder_vip/web_client/views/UploadFolderWidget.js
@@ -1,10 +1,10 @@
 // Import utilities
-import { wrap } from '@girder/core/utilities/PluginUtils';
-import { formatSize } from "@girder/core/misc";
-import FolderModel from '@girder/core/models/FolderModel'
+const { wrap } = girder.utilities.PluginUtils;
+const { formatSize } = girder.misc;
+const FolderModel = girder.models.FolderModel;
 
 // Import views
-import UploadWidget from "@girder/core/views/widgets/UploadWidget";
+const UploadWidget = girder.views.widgets.UploadWidget;
 
 // Import templates
 import UploadFolderCheckboxTemplate from '../templates/uploadFolderCheckbox.pug';

--- a/girder_vip/web_client/views/UserAccountView.js
+++ b/girder_vip/web_client/views/UserAccountView.js
@@ -1,13 +1,13 @@
 // Import utilities
-import { wrap } from '@girder/core/utilities/PluginUtils';
-import { getCurrentUser } from '@girder/core/auth';
+const { wrap } = girder.utilities.PluginUtils;
+const { getCurrentUser } = girder.auth;
 import {saveVipApiKey, messageGirder, updateApiKeysConfiguration, verifyApiKeysConfiguration} from '../utilities/vipPluginUtils';
-import router from '@girder/core/router';
-import events from '@girder/core/events';
+const router = girder.router;
+const events = girder.events;
 import * as constants from '../constants';
 
 // Import views
-import UserAccountView from '@girder/core/views/body/UserAccountView';
+const UserAccountView = girder.views.body.UserAccountView;
 
 // Import templates
 import UserAccountTab from '../templates/userAccountTab.pug';

--- a/girder_vip/web_client/webpack.config.js
+++ b/girder_vip/web_client/webpack.config.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const PugPlugin = require('pug-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+    mode: 'production',
+    devtool: false,
+    entry: './main.js',
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'vip-plugin.umd.js',
+        clean: true,
+    },
+    resolve: {
+        extensions: ['.js', '.pug'],
+    },
+    externals: {
+        jquery: 'jQuery',
+        underscore: '_',
+        backbone: 'Backbone',
+        moment: 'moment',
+        girder: 'girder',
+    },
+    plugins: [
+        new PugPlugin(),
+        new webpack.ProvidePlugin({
+            $: ['girder', '$'],
+            jQuery: ['girder', '$'],
+            _: ['girder', '_'],
+            Backbone: ['girder', 'Backbone'],
+            moment: ['girder', 'moment'],
+        })
+    ],
+};

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 from setuptools import setup, find_packages
 setup(
     name='girder-vip',            # The name registered on PyPI
-    version='3.0.0',
+    version='3.0.3',
     description='Use VIP applications.', # This text will be displayed on the plugin page
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    setup_requires=['setuptools-git'],
-    install_requires=['girder>=3'],      # Add any plugin dependencies here
+    install_requires=['girder>=5'],      # Add any plugin dependencies here
     entry_points={
       'girder.plugin': [              # Register the plugin with girder.  The next line registers
                                       # our plugin under the name "example".  The name here must be

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['plugin_tests']),
     zip_safe=False,
-    install_requires=['girder>=5'],      # Add any plugin dependencies here
+    install_requires=['girder==5.0.1'],      # Add any plugin dependencies here
+    setup_requires=['setuptools-git'],
     entry_points={
       'girder.plugin': [              # Register the plugin with girder.  The next line registers
                                       # our plugin under the name "example".  The name here must be


### PR DESCRIPTION
Refactor VIP Girder plugin to use [Girder 5.x.](https://girder.readthedocs.io/en/stable/migration-guide.html) 
Since it's a pretty big update there is a lot of changes : 

- front-end build is now handled by the user : via `npm install` and `npm run build` with a webpack bundle
- backend is now async and also on the charge of the user : large tasks and girder messages require a background worker, provided by celery and girder-worker automatically through a command line. Redis-server needs to be installed and running, environment variables set, and additional plugin girder-plugin-worker installed.
- js imports have a new pattern


